### PR TITLE
Fixed a bug that occurs after adapter.add(item);

### DIFF
--- a/dynamicgrid/src/org/askerov/dynamicgrid/AbstractDynamicGridAdapter.java
+++ b/dynamicgrid/src/org/askerov/dynamicgrid/AbstractDynamicGridAdapter.java
@@ -54,6 +54,7 @@ public abstract class AbstractDynamicGridAdapter extends BaseAdapter implements 
         for (int i = startId; i < items.size(); i++) {
             mIdMap.put(items.get(i), i);
         }
+        nextStableId=mIdMap.size();
     }
 
     /**


### PR DESCRIPTION
```
when I called adapter.add(Item), all the childViews going to wrong position in editmode.
but I already fixed it. I have noticed that AbstractDynamicGridAdapter#nextStableId has not been changed in the AbstractDynamicGridAdapter#addAllStableId method.
So I was added "nextStableId=mIdMap.size();" to the end of the addAllStatbleId method and it works fine.

My English is not good, hope you can understand me, thank you!
```
