### PR TITLE
Add a way to disable reordering on specific tiles

### DIFF
--- a/dynamicgrid/src/org/askerov/dynamicgrid/BaseDynamicGridAdapter.java
+++ b/dynamicgrid/src/org/askerov/dynamicgrid/BaseDynamicGridAdapter.java
@@ -99,6 +99,11 @@ public abstract class BaseDynamicGridAdapter extends AbstractDynamicGridAdapter 
         }
     }
 
+    @Override
+    public boolean canReorder(int position) {
+        return true;
+    }
+
     public List<Object> getItems() {
         return mItems;
     }

--- a/dynamicgrid/src/org/askerov/dynamicgrid/DynamicGridAdapterInterface.java
+++ b/dynamicgrid/src/org/askerov/dynamicgrid/DynamicGridAdapterInterface.java
@@ -25,4 +25,9 @@ public interface DynamicGridAdapterInterface {
      */
     int getColumnCount();
 
+    /**
+     * Determines whether the item in the specified <code>position</code> can be reordered.
+     */
+    boolean canReorder(int position);
+
 }

--- a/dynamicgrid/src/org/askerov/dynamicgrid/DynamicGridView.java
+++ b/dynamicgrid/src/org/askerov/dynamicgrid/DynamicGridView.java
@@ -371,7 +371,7 @@ public class DynamicGridView extends GridView {
         idList.clear();
         int draggedPos = getPositionForID(itemId);
         for (int pos = getFirstVisiblePosition(); pos <= getLastVisiblePosition(); pos++) {
-            if (draggedPos != pos) {
+            if (draggedPos != pos && getAdapterInterface().canReorder(pos)) {
                 idList.add(getId(pos));
             }
         }
@@ -720,7 +720,8 @@ public class DynamicGridView extends GridView {
             final int originalPosition = getPositionForView(mMobileView);
             int targetPosition = getPositionForView(targetView);
 
-            if (targetPosition == INVALID_POSITION) {
+            final DynamicGridAdapterInterface adapter = getAdapterInterface();
+            if (targetPosition == INVALID_POSITION || !adapter.canReorder(originalPosition) || !adapter.canReorder(targetPosition)) {
                 updateNeighborViewsForId(mMobileItemId);
                 return;
             }


### PR DESCRIPTION
In my use case, I need to disable certain tiles from being reordered.

This change adds `canReorder(boolean)` to the `DynamicGridAdapterInterface`.
And the default implementation in `BaseDynamicGridAdapter` returns `true` for all positions.